### PR TITLE
SFS changes for 6 hourly output, direct latlon, and removal of atmos products

### DIFF
--- a/dev/ci/cases/yamls/sfs_full_C192mx025_CPC_ICS.yaml
+++ b/dev/ci/cases/yamls/sfs_full_C192mx025_CPC_ICS.yaml
@@ -2,7 +2,7 @@ defaults:
   !INC {{ HOMEgfs }}/dev/parm/config/sfs/yaml/defaults.yaml
 base:
   FHMAX_GFS: 8760
-  FCST_BREAKPOINTS: "2190, 4380, 6570"
+  FCST_BREAKPOINTS: "2400, 4800, 7200"
 ocn:
   MOM6_INTERP_ICS: "YES"
 nsst:

--- a/dev/ci/cases/yamls/sfs_full_C96mx100_CPC_ICS.yaml
+++ b/dev/ci/cases/yamls/sfs_full_C96mx100_CPC_ICS.yaml
@@ -2,7 +2,7 @@ defaults:
   !INC {{ HOMEgfs }}/dev/parm/config/sfs/yaml/defaults.yaml
 base:
   FHMAX_GFS: 8760
-  FCST_BREAKPOINTS: "2190, 4380, 6570"
+  FCST_BREAKPOINTS: "2400, 4800, 7200"
 ocn:
   MOM6_INTERP_ICS: "NO"
 nsst:

--- a/dev/parm/config/sfs/config.base.j2
+++ b/dev/parm/config/sfs/config.base.j2
@@ -271,7 +271,8 @@ export QUILTING=".true."
 #export OUTPUT_GRID="gaussian_grid"
 export OUTPUT_GRID="global_latlon"
 export WRITE_DOPOST=".true." # WRITE_DOPOST=true, use inline POST
-export WRITE_NSFLIP=".false."
+export OUTPUT_HISTORY=".false." # if true, write netcdf files
+export WRITE_NSFLIP=".true."
 
 # Microphysics Options: 99-ZhaoCarr, 8-Thompson; 6-WSM6, 10-MG, 11-GFDL
 export imp_physics=8

--- a/dev/parm/config/sfs/config.base.j2
+++ b/dev/parm/config/sfs/config.base.j2
@@ -261,16 +261,17 @@ export FHOUT_OCN=${FHOUT_OCN_GFS}
 export FHOUT_ICE=${FHOUT_ICE_GFS}
 
 # GFS restart interval in hours
-export restart_interval_gfs=72
+export restart_interval_gfs=240
 export restart_interval_enkfgfs=12
 # NOTE: Do not set this to zero.  Instead set it to $FHMAX_GFS
 # TODO: Remove this variable from config.base and reference from config.fcst
 # TODO: rework logic in config.wave and push it to parsing_nameslist_WW3.sh where it is actually used
 
 export QUILTING=".true."
-export OUTPUT_GRID="gaussian_grid"
+#export OUTPUT_GRID="gaussian_grid"
+export OUTPUT_GRID="global_latlon"
 export WRITE_DOPOST=".true." # WRITE_DOPOST=true, use inline POST
-export WRITE_NSFLIP=".true."
+export WRITE_NSFLIP=".false."
 
 # Microphysics Options: 99-ZhaoCarr, 8-Thompson; 6-WSM6, 10-MG, 11-GFDL
 export imp_physics=8

--- a/dev/parm/config/sfs/config.resources
+++ b/dev/parm/config/sfs/config.resources
@@ -321,6 +321,13 @@ case ${step} in
     export threads_per_task=1
     export memory="4096M"
     ;;
+  "globus")
+    export walltime="06:00:00"
+    export ntasks=1
+    export tasks_per_node=1
+    export threads_per_task=1
+    export memory="4096M"
+    ;;
   *)
     echo "FATAL ERROR: Invalid job ${step} passed to ${BASH_SOURCE[0]}"
     exit 1

--- a/dev/parm/config/sfs/yaml/defaults.yaml
+++ b/dev/parm/config/sfs/yaml/defaults.yaml
@@ -12,9 +12,9 @@ base:
   FCST_BREAKPOINTS: "48"
   REPLAY_ICS: "NO"
   FHMAX_HF_GFS: 0
-  FHOUT_HF_GFS: 24
+  FHOUT_HF_GFS: 6 
   FHMAX_GFS: 120
-  FHOUT_GFS: 24
+  FHOUT_GFS: 6
   FHOUT_OCN_GFS: 24
   FHOUT_ICE_GFS: 24
   HPSSARCH: "YES"
@@ -24,7 +24,7 @@ base:
   DO_TEST_MODE: "NO"
 fcst:
   reforecast: "YES"
-  FHZERO: 24
+  FHZERO: 6
   TYPE: "hydro"
   MONO: "mono"
 ocn:

--- a/dev/workflow/applications/sfs.py
+++ b/dev/workflow/applications/sfs.py
@@ -72,18 +72,15 @@ class SFSAppConfig(AppConfig):
             List of configuration file names needed for the SFS run
         """
         options = self.run_options[run]
-        configs = ['stage_ic', 'fcst', 'atmos_products']
+        configs = ['stage_ic', 'fcst']
 
         if options['nens'] > 0:
-            configs += ['efcs', 'atmos_ensstat']
+            configs += ['efcs']
 
         if options['do_wave']:
             configs += ['waveinit', 'wavepostsbs', 'wavepostpnt']
             if options['do_wave_bnd']:
                 configs += ['wavepostbndpnt', 'wavepostbndpntbll']
-
-        if options['do_ocean'] or options['do_ice']:
-            configs += ['oceanice_products']
 
         if options['do_aero_fcst']:
             configs += ['prep_emissions']
@@ -146,16 +143,6 @@ class SFSAppConfig(AppConfig):
         if options['nens'] > 0:
             tasks += ['efcs']
 
-        tasks += ['atmos_prod']
-
-        if options['nens'] > 0:
-            tasks += ['atmos_ensstat']
-
-        if options['do_ocean']:
-            tasks += ['ocean_prod']
-
-        if options['do_ice']:
-            tasks += ['ice_prod']
 
         if options['do_wave']:
             tasks += ['wavepostsbs']

--- a/parm/archive/atmos_master_grib.yaml.j2
+++ b/parm/archive/atmos_master_grib.yaml.j2
@@ -1,0 +1,18 @@
+{% set cycle_YMDH = current_cycle | to_YMDH %}
+{% set head = RUN ~ ".t" ~ cycle_HH ~ "z.*.1p00." %}
+atmos_master_grib:
+    name: "ATMOS_MASTER_grib"
+    target: "{{ ATARDIR }}/{{ cycle_YMDH }}/atmos_master_grib.tar"
+    required:
+        - "{{ COMIN_ATMOS_MASTER | relpath(ROTDIR) }}/{{ head }}*"
+        {% for mem in range(1, NMEM_ENS + 1) %}
+        {% set mem_char = 'mem%03d' | format(mem) %}
+        {% set tmpl_dict = ({ '${ROTDIR}':ROTDIR,
+                              '${RUN}':RUN,
+                              '${YMD}':cycle_YMD,
+                              '${HH}':cycle_HH,
+                              '${MEMDIR}': mem_char,
+                              '${GRID}': '1p00' }) %}
+        {% set COMIN_ATMOS_MASTER = COM_ATMOS_MASTER_TMPL | replace_tmpl(tmpl_dict) %}
+        - "{{ COMIN_ATMOS_MASTER | relpath(ROTDIR) }}/{{ head }}*"
+        {% endfor %}

--- a/parm/archive/master_sfs.yaml.j2
+++ b/parm/archive/master_sfs.yaml.j2
@@ -11,12 +11,16 @@ datasets:
 {% endfilter %}
 {% endif %}
 
-{% filter indent(width=4) %}
-{% include "atmos_products_0p50.yaml.j2" %}
-{% endfilter %}
+#{% filter indent(width=4) %}
+#{% include "atmos_products_0p50.yaml.j2" %}
+#{% endfilter %}
 
+#{% filter indent(width=4) %}
+#{% include "atmos_products_1p00.yaml.j2" %}
+#{% endfilter %}
+#
 {% filter indent(width=4) %}
-{% include "atmos_products_1p00.yaml.j2" %}
+{% include "atmos_master_grib.yaml.j2" %}
 {% endfilter %}
 
 {% filter indent(width=4) %}

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -279,7 +279,8 @@ EOF
   #============================================================================
 
   #============================================================================
-  if [[ "${QUILTING}" = ".true." ]] && [[ "${OUTPUT_GRID}" = "gaussian_grid" ]]; then
+  #if [[ "${QUILTING}" = ".true." ]] && [[ "${OUTPUT_GRID}" = "gaussian_grid" ]]; then
+  if [[ "${QUILTING}" = ".true." ]] ; then
     local FH2 FH3
     for fhr in ${FV3_OUTPUT_FH}; do
       FH3=$(printf %03i "${fhr}")
@@ -290,17 +291,21 @@ EOF
         local hhmmss_substring=${FV3_OUTPUT_FH_hhmmss/" ${FH3}-"*/} # Extract substring that contains all lead times up to the one space before target lead HHH-MM-SS
         local hhmmss_substring_len=$(( ${#hhmmss_substring} + 1 )) # Get the size of the substring and add 1 to account for space
         local f_hhmmss=${FV3_OUTPUT_FH_hhmmss:${hhmmss_substring_len}:9} # extract HHH-MM-SS for target lead time
-        ${NLN} "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.atmf${FH3}.nc" "atmf${f_hhmmss}.nc"
-        ${NLN} "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.sfcf${FH3}.nc" "sfcf${f_hhmmss}.nc"
-        ${NLN} "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.atm.logf${FH3}.txt" "log.atm.f${f_hhmmss}"
+	if [ ${OUTPUT_HISTORY} == ".true." ];then
+           ${NLN} "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.atmf${FH3}.nc" "atmf${f_hhmmss}.nc"
+           ${NLN} "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.sfcf${FH3}.nc" "sfcf${f_hhmmss}.nc"
+           ${NLN} "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.atm.logf${FH3}.txt" "log.atm.f${f_hhmmss}"
+	fi
       else
-        ${NLN} "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.atmf${FH3}.nc" "atmf${FH3}.nc"
-        ${NLN} "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.sfcf${FH3}.nc" "sfcf${FH3}.nc"
-        ${NLN} "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.atm.logf${FH3}.txt" "log.atm.f${FH3}"
-        if [[ "${DO_JEDIATMVAR:-}" == "YES" ]]; then
-          ${NLN} "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.cubed_sphere_grid_atmf${FH3}.nc" "cubed_sphere_grid_atmf${FH3}.nc"
-          ${NLN} "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.cubed_sphere_grid_sfcf${FH3}.nc" "cubed_sphere_grid_sfcf${FH3}.nc"
-        fi
+	if [ ${OUTPUT_HISTORY} == ".true." ];then
+           ${NLN} "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.atmf${FH3}.nc" "atmf${FH3}.nc"
+           ${NLN} "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.sfcf${FH3}.nc" "sfcf${FH3}.nc"
+           ${NLN} "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.atm.logf${FH3}.txt" "log.atm.f${FH3}"
+           if [[ "${DO_JEDIATMVAR:-}" == "YES" ]]; then
+             ${NLN} "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.cubed_sphere_grid_atmf${FH3}.nc" "cubed_sphere_grid_atmf${FH3}.nc"
+             ${NLN} "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.cubed_sphere_grid_sfcf${FH3}.nc" "cubed_sphere_grid_sfcf${FH3}.nc"
+           fi
+         fi
       fi
       if [[ "${WRITE_DOPOST}" == ".true." ]]; then
         ${NLN} "${COMOUT_ATMOS_MASTER}/${RUN}.t${cyc}z.master.grb2f${FH3}" "GFSPRS.GrbF${FH2}"

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -245,8 +245,19 @@ FV3_predet(){
   LONB=${LONB:-${LONB_CASE}}
   LATB=${LATB:-${LATB_CASE}}
 
-  LONB_IMO=${LONB_IMO:-${LONB_CASE}}
-  LATB_JMO=${LATB_JMO:-${LATB_CASE}}
+  #LONB_IMO=${LONB_IMO:-${LONB_CASE}}
+  #LATB_JMO=${LATB_JMO:-${LATB_CASE}}
+  # for SFS runs
+  if [ $res -eq 96 ];then
+     LONB_IMO=360
+     LATB_JMO=181
+  elif [ $res -eq 192 ];then
+     LONB_IMO=720
+     LATB_JMO=361
+  else
+     LONB_IMO=${LONB_IMO:-${LONB_CASE}}
+     LATB_JMO=${LATB_JMO:-${LATB_CASE}}
+  fi
 
   # NSST Options
   # nstf_name contains the NSST related parameters


### PR DESCRIPTION
These update include
Write 6 hourly atmospheric output directly on a latlon grid
removal of all products jobs
removal of ensstat job
write restart every 10 days and make forecast segments a factor of 10 days
and a place holder of globus task for hercules.

I have not tested all of this just yeat.