### PR TITLE
add river runoff option to 1-deg MOM_input

### DIFF
--- a/dev/parm/config/gefs/config.ufs
+++ b/dev/parm/config/gefs/config.ufs
@@ -306,7 +306,7 @@ if [[ "${skip_mom6}" == "false" ]]; then
       FRUNOFF="runoff.daitren.clim.1deg.nc"
       CHLCLIM="seawifs_1998-2006_smoothed_2X.nc"
       MOM6_RESTART_SETTING=${MOM6_RESTART_SETTING:-'r'}
-      MOM6_RIVER_RUNOFF='False'
+      MOM6_RIVER_RUNOFF='True'
       eps_imesh="2.5e-1"
       TOPOEDITS="ufs.topo_edits_011818.nc"
       case ${RUN} in


### PR DESCRIPTION
This PR sets RUNOFF to true in config.ufs for the 1-degree setup. There is also a PR for the ufs-weather model since the MOM_input template namelist comes from the tests directory.